### PR TITLE
Fhir harmoney/patient fields

### DIFF
--- a/src/edu/gatech/i3l/HealthPort/HealthPortInfo.java
+++ b/src/edu/gatech/i3l/HealthPort/HealthPortInfo.java
@@ -54,6 +54,13 @@ public class HealthPortInfo {
 	public String gender = null;
 	public String contact = null;
 	public String address = null;
+	public Date dob = null;
+	public String ethnicity = null;
+	public String maritalStatus = null;
+	public String bloodType = null;
+	public String job = null;
+	public String advanceDirective = null;
+	public String organDonor = null;
 
 	// Database Paging Resource Names
 	public static String OBSERVATION = "OBSERVATION";
@@ -762,13 +769,20 @@ public class HealthPortInfo {
 
 	public void resetInformation() {
 		userId = null;
-		name = null;
+		name = "";
 		recordId = null;
 		personId = null;
 		source = null;
 		gender = null;
 		contact = null;
 		address = null;
+		dob = null;
+		ethnicity = null;
+		maritalStatus = null;
+		bloodType = null;
+		job = null;
+		advanceDirective = null;
+		organDonor = null;
 	}
 
 	public void setRSInformation(ResultSet rs) throws SQLException {
@@ -781,27 +795,34 @@ public class HealthPortInfo {
 		gender = rs.getString("GENDER");
 		contact = rs.getString("CONTACT");
 		address = rs.getString("ADDRESS");
+		dob = rs.getDate("DOB");
+		ethnicity = rs.getString("ETHNICITY");
+		maritalStatus = rs.getString("MARITAL_STATUS");
+		bloodType = rs.getString("BLOOD_TYPE");
+		job = rs.getString("JOB");
+		advanceDirective = rs.getString("ADVANCE_DIRECTIVE");
+		organDonor = rs.getString("ORGAN_DONOR");
 	}
 
-	public void setInformation(String userId) {
+	public void setInformation(String qPersonId) {
 		Connection connection = null;
-		Statement statement = null;
-		// Context context = null;
-		// DataSource datasource = null;
 
-		this.userId = userId;
+		this.personId = qPersonId;
 
 		try {
 			connection = getConnection();
-			statement = connection.createStatement();
-			String SQL_STATEMENT = "SELECT U1.ID, U1.ORGANIZATIONID, U1.NAME, ORG.TAG, U1.RECORDID, U1.PERSONID, U1.GENDER, U1.CONTACT, U1.ADDRESS FROM USER AS U1 LEFT JOIN ORGANIZATION AS ORG ON (ORG.ID=U1.ORGANIZATIONID) WHERE U1.ID="
-					+ userId;
-			ResultSet resultSet = statement.executeQuery(SQL_STATEMENT);
+			final String SQL_STATEMENT = "SELECT U1.ID, U1.ORGANIZATIONID, U1.NAME, ORG.TAG, U1.RECORDID, U1.PERSONID, U1.GENDER, U1.CONTACT, U1.ADDRESS, U1.DOB, U1.ETHNICITY, U1.MARITAL_STATUS, U1.BLOOD_TYPE, U1.JOB, U1.ADVANCE_DIRECTIVE, U1.ORGAN_DONOR FROM USER AS U1 LEFT JOIN ORGANIZATION AS ORG ON (ORG.ID=U1.ORGANIZATIONID) "
+					+ " WHERE U1.ID=?;";
+			PreparedStatement psPatientId = connection
+					.prepareStatement(SQL_STATEMENT);
+			psPatientId.setString(1, qPersonId);
+			ResultSet resultSet = psPatientId.executeQuery();
 
 			if (resultSet.next()) {
 				setRSInformation(resultSet);
-				// System.out.println("[HealthPortUserInfo]"+userId);
-				// System.out.println("[HealthPortUserInfo]"+name+":"+dataSource);
+			} else {
+				// No record found, reset the record
+				resetInformation();
 			}
 
 		} catch (Exception e) {
@@ -816,25 +837,25 @@ public class HealthPortInfo {
 		}
 	}
 
-	public void setInformationPersonID(String Id, String OrgID) {
+	public void setInformationPersonID(String qPersonId, String qOrgId) {
 		Connection connection = null;
-		Statement statement = null;
-		// Context context = null;
-		// DataSource datasource = null;
-
-		this.personId = Id;
 
 		try {
 			connection = getConnection();
-			statement = connection.createStatement();
-			String SQL_STATEMENT = "SELECT U1.ID, U1.ORGANIZATIONID, U1.NAME, ORG.TAG, U1.RECORDID, U1.PERSONID, U1.GENDER, U1.CONTACT, U1.ADDRESS FROM USER AS U1 LEFT JOIN ORGANIZATION AS ORG ON (ORG.ID=U1.ORGANIZATIONID) WHERE U1.PERSONID='"
-					+ Id + "' AND U1.ORGANIZATIONID='" + OrgID + "'";
-			ResultSet resultSet = statement.executeQuery(SQL_STATEMENT);
+
+			final String SQL_STATEMENT = "SELECT U1.ID, U1.ORGANIZATIONID, U1.NAME, ORG.TAG, U1.RECORDID, U1.PERSONID, U1.GENDER, U1.CONTACT, U1.ADDRESS, U1.DOB, U1.ETHNICITY, U1.MARITAL_STATUS, U1.BLOOD_TYPE, U1.JOB, U1.ADVANCE_DIRECTIVE, U1.ORGAN_DONOR FROM USER AS U1 LEFT JOIN ORGANIZATION AS ORG ON (ORG.ID=U1.ORGANIZATIONID) "
+					+ " WHERE U1.PERSONID=? AND U1.ORGANIZATIONID=?;";
+			PreparedStatement psPatient = connection
+					.prepareStatement(SQL_STATEMENT);
+			psPatient.setString(1, qPersonId);
+			psPatient.setString(2, qOrgId);
+			ResultSet resultSet = psPatient.executeQuery();
 
 			if (resultSet.next()) {
 				setRSInformation(resultSet);
-				// System.out.println("[HealthPortUserInfo]"+userId);
-				// System.out.println("[HealthPortUserInfo]"+name+":"+dataSource);
+			} else {
+				// No record found, reset the record
+				resetInformation();
 			}
 		} catch (Exception e) {
 			e.printStackTrace();

--- a/src/edu/gatech/i3l/HealthPort/HealthPortInfo.java
+++ b/src/edu/gatech/i3l/HealthPort/HealthPortInfo.java
@@ -3,19 +3,14 @@
  */
 package edu.gatech.i3l.HealthPort;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.ObjectInputStream;
 import java.sql.Connection;
+import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.sql.Date;
 import java.util.List;
 
 import javax.naming.InitialContext;
@@ -33,9 +28,9 @@ import ca.uhn.fhir.model.dstu.composite.ResourceReferenceDt;
 import ca.uhn.fhir.model.dstu.resource.Condition;
 import ca.uhn.fhir.model.dstu.resource.Medication;
 import ca.uhn.fhir.model.dstu.resource.MedicationPrescription;
-import ca.uhn.fhir.model.dstu.resource.Observation;
 import ca.uhn.fhir.model.dstu.resource.MedicationPrescription.Dispense;
 import ca.uhn.fhir.model.dstu.resource.MedicationPrescription.DosageInstruction;
+import ca.uhn.fhir.model.dstu.resource.Observation;
 import ca.uhn.fhir.model.dstu.valueset.ConditionStatusEnum;
 import ca.uhn.fhir.model.dstu.valueset.MedicationPrescriptionStatusEnum;
 import ca.uhn.fhir.model.dstu.valueset.NarrativeStatusEnum;
@@ -83,16 +78,18 @@ public class HealthPortInfo {
 		setInformation(userId);
 	}
 
-	public List<String> getResourceIdsByPatientCode (String tableName, String patientId, List<String> codes) {
+	public List<String> getResourceIdsByPatientCode(String tableName,
+			String patientId, List<String> codes) {
 		List<String> retVal = new ArrayList<String>();
 		Connection connection = null;
 		Statement statement = null;
 
 		if (codes.isEmpty()) {
-			// If list of code is empty, this is basically same as getResourceIdsByPatient
+			// If list of code is empty, this is basically same as
+			// getResourceIdsByPatient
 			return getResourceIdsByPatient(tableName, patientId);
 		}
-		
+
 		String SQL_STATEMENT = "SELECT ID FROM " + tableName
 				+ " WHERE SUBJECT = 'Patient/" + patientId + "' AND (";
 		if (tableName.equals(OBSERVATION)) {
@@ -100,17 +97,18 @@ public class HealthPortInfo {
 			boolean start = true;
 			for (String code : codes) {
 				if (start) {
-					SQL_STATEMENT += "NAMECODING = '" + code +"'";
-					start = false; 
+					SQL_STATEMENT += "NAMECODING = '" + code + "'";
+					start = false;
 				} else {
-					SQL_STATEMENT += " OR NAMECODING = '" + code +"'";
+					SQL_STATEMENT += " OR NAMECODING = '" + code + "'";
 				}
 			}
 			SQL_STATEMENT += ")";
 		}
-		
-		System.out.println (SQL_STATEMENT);
-		System.out.println ("HealthPortInfo: getResourceIdsByPatientCode: "+tableName+" for Patient="+patientId+" and Codes");
+
+		System.out.println(SQL_STATEMENT);
+		System.out.println("HealthPortInfo: getResourceIdsByPatientCode: "
+				+ tableName + " for Patient=" + patientId + " and Codes");
 		connection = getConnection();
 		try {
 			statement = connection.createStatement();
@@ -124,17 +122,17 @@ public class HealthPortInfo {
 		} finally {
 			try {
 				connection.close();
-			} catch (SQLException e) {				// TODO Auto-generated catch block
+			} catch (SQLException e) { // TODO Auto-generated catch block
 				e.printStackTrace();
 			}
 		}
 
-		System.out.println ("HealthPortInfo: getResourceIdsByPatientCode: Done");
-		
+		System.out.println("HealthPortInfo: getResourceIdsByPatientCode: Done");
+
 		return retVal;
 	}
-	
-	public List<String> getResourceIdsByPatient (String tableName,
+
+	public List<String> getResourceIdsByPatient(String tableName,
 			String patientId) {
 		List<String> retVal = new ArrayList<String>();
 
@@ -144,7 +142,8 @@ public class HealthPortInfo {
 		String SQL_STATEMENT = "SELECT ID FROM " + tableName
 				+ " WHERE SUBJECT = 'Patient/" + patientId + "'";
 
-		System.out.println ("HealthPortInfo: getResourceIdsByPatient: "+tableName+" for Patient "+patientId);
+		System.out.println("HealthPortInfo: getResourceIdsByPatient: "
+				+ tableName + " for Patient " + patientId);
 		connection = getConnection();
 		try {
 			statement = connection.createStatement();
@@ -158,12 +157,12 @@ public class HealthPortInfo {
 		} finally {
 			try {
 				connection.close();
-			} catch (SQLException e) {				// TODO Auto-generated catch block
+			} catch (SQLException e) { // TODO Auto-generated catch block
 				e.printStackTrace();
 			}
 		}
 
-		System.out.println ("HealthPortInfo: getResourceIdsByPatient: Done");
+		System.out.println("HealthPortInfo: getResourceIdsByPatient: Done");
 
 		return retVal;
 	}
@@ -178,7 +177,8 @@ public class HealthPortInfo {
 		String SQL_STATEMENT = "SELECT ID FROM " + tableName
 				+ " WHERE NAMECODING = '" + code + "'";
 
-		System.out.println ("HealthPortInfo: getResourceIdsByCodeSystem: "+tableName+" for codesys/code "+codeSystem+"/"+code);
+		System.out.println("HealthPortInfo: getResourceIdsByCodeSystem: "
+				+ tableName + " for codesys/code " + codeSystem + "/" + code);
 		connection = getConnection();
 
 		try {
@@ -197,7 +197,7 @@ public class HealthPortInfo {
 				e.printStackTrace();
 			}
 		}
-		System.out.println ("HealthPortInfo: getResourceIdsByCodeSystem: done");
+		System.out.println("HealthPortInfo: getResourceIdsByCodeSystem: done");
 
 		return retVal;
 	}
@@ -210,7 +210,7 @@ public class HealthPortInfo {
 
 		String SQL_STATEMENT = "SELECT ID FROM " + tableName;
 
-		System.out.println ("HealthPortInfo: getAllResoureIds: "+tableName);
+		System.out.println("HealthPortInfo: getAllResoureIds: " + tableName);
 		connection = getConnection();
 		try {
 			statement = connection.createStatement();
@@ -229,7 +229,7 @@ public class HealthPortInfo {
 			}
 		}
 
-		System.out.println ("HealthPortInfo: getAllResoureIds: done");
+		System.out.println("HealthPortInfo: getAllResoureIds: done");
 		return retVal;
 	}
 
@@ -365,10 +365,10 @@ public class HealthPortInfo {
 		Statement getRes = null;
 
 		try {
-//			DataSource ds = (DataSource) new InitialContext()
-//					.lookup("java:/comp/env/jdbc/HealthPort");
-//
-//			connection = ds.getConnection();
+			// DataSource ds = (DataSource) new InitialContext()
+			// .lookup("java:/comp/env/jdbc/HealthPort");
+			//
+			// connection = ds.getConnection();
 			connection = getConnection();
 			getRes = connection.createStatement();
 			// System.out.println("reading from OBSERVATION: "+Ids.size());
@@ -863,7 +863,6 @@ public class HealthPortInfo {
 				// System.out.println("[HealthPortUserInfo]"+name+":"+dataSource);
 			}
 
-			
 		} catch (Exception e) {
 			e.printStackTrace();
 			resetInformation();

--- a/src/edu/gatech/i3l/HealthPort/providers/PatientResourceProvider.java
+++ b/src/edu/gatech/i3l/HealthPort/providers/PatientResourceProvider.java
@@ -5,9 +5,12 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import ca.uhn.fhir.model.dstu.resource.Patient;
 import ca.uhn.fhir.model.dstu.valueset.AdministrativeGenderCodesEnum;
+import ca.uhn.fhir.model.dstu.valueset.MaritalStatusCodesEnum;
 import ca.uhn.fhir.model.dstu.valueset.NarrativeStatusEnum;
 import ca.uhn.fhir.model.primitive.IdDt;
 import ca.uhn.fhir.model.primitive.UriDt;
@@ -23,7 +26,7 @@ import edu.gatech.i3l.HealthPort.ports.HealthVaultPort;
  * All resource providers must implement IResourceProvider
  */
 public class PatientResourceProvider implements IResourceProvider {
-	public static final String SQL_STATEMENT = "SELECT U1.ID, U1.ORGANIZATIONID, U1.NAME, ORG.TAG, U1.RECORDID, U1.PERSONID, U1.GENDER, U1.CONTACT, U1.ADDRESS FROM USER AS U1 LEFT JOIN ORGANIZATION AS ORG ON (ORG.ID=U1.ORGANIZATIONID)";
+	public static final String SQL_STATEMENT = "SELECT U1.ID, U1.ORGANIZATIONID, U1.NAME, ORG.TAG, U1.RECORDID, U1.PERSONID, U1.GENDER, U1.CONTACT, U1.ADDRESS, U1.DOB, U1.ETHNICITY, U1.MARITAL_STATUS, U1.BLOOD_TYPE, U1.JOB, U1.ADVANCE_DIRECTIVE, U1.ORGAN_DONOR FROM USER AS U1 LEFT JOIN ORGANIZATION AS ORG ON (ORG.ID=U1.ORGANIZATIONID);";
 
 	private HealthPortInfo healthPortUser;
 	private String GWID;
@@ -47,55 +50,27 @@ public class PatientResourceProvider implements IResourceProvider {
 	@Read()
 	public Patient getResourceById(@IdParam IdDt theId) {
 		Patient patient = new Patient();
-		// FhirContext ctx = new FhirContext();
-		// int id = Integer.parseInt(theId.getIdPart());
-		// HealthPortUserInfo HealthPortUser = new HealthPortUserInfo(id);
-
 		String Ids[] = theId.getIdPart().split("\\.", 2);
-		String patientID;
 
+		// Verify ID token length
 		if (Ids.length != 2) {
 			return patient;
 		}
 		if (Ids[0].equals(GWID) || Ids[0].equals(HVID)) {
+			// Search for patient record by ID
 			healthPortUser.setInformation(Ids[1]);
-			patientID = healthPortUser.orgID + "." + healthPortUser.userId;
 		} else {
+			// Search for patient record by ID & Org ID
 			healthPortUser.setInformationPersonID(Ids[1], Ids[0]);
-			patientID = healthPortUser.orgID + "." + healthPortUser.personId;
 		}
 
-		if (healthPortUser.orgID == null)
+		// Verify successful patient search
+		if (healthPortUser.name.isEmpty()) {
 			return null;
-
-		patient.addIdentifier();
-		patient.getIdentifier().get(0)
-				.setSystem(new UriDt("urn:healthport:mrns"));
-		patient.setId(patientID);
-		patient.getIdentifier().get(0).setValue(patientID);
-
-		String fullName = null;
-
-		String[] userName = healthPortUser.name.split(" ");
-		if (userName.length == 2) {
-			patient.addName().addFamily(userName[1]);
-			patient.getName().get(0).addGiven(userName[0]);
-			fullName = userName[0] + " " + userName[1];
-		} else {
-			patient.addName().addFamily(userName[2]);
-			patient.getName().get(0).addGiven(userName[0] + " " + userName[1]);
-			fullName = userName[0] + " " + userName[1] + " " + userName[2];
 		}
-		// ctx.setNarrativeGenerator(new DefaultThymeleafNarrativeGenerator());
-		// // Encode the output, including the narrative
-		// String output =
-		// ctx.newXmlParser().setPrettyPrint(true).encodeResourceToString(patient);
-		// //patient.getText().setDiv(output);
 
-		patient.getText().setStatus(NarrativeStatusEnum.GENERATED);
-		String textBody = "<table>" + "<tr><td>Name</td><td>" + fullName
-				+ "</td></tr></table>";
-		patient.getText().setDiv(textBody);
+		// Process Java object into FHIR Patient Resource object
+		patient = buildPatient(healthPortUser);
 
 		return patient;
 	}
@@ -112,66 +87,11 @@ public class PatientResourceProvider implements IResourceProvider {
 			statement = connection.createStatement();
 			ResultSet resultSet = statement.executeQuery(SQL_STATEMENT);
 			while (resultSet.next()) {
+				// Process Result Set object into Java object
 				healthPortUser.setRSInformation(resultSet);
-				String[] userName = healthPortUser.name.split(" ");
-
-				Patient patient = new Patient();
-				patient.addIdentifier();
-				patient.getIdentifier().get(0)
-						.setSystem(new UriDt("urn:healthport:mrns"));
-				if (healthPortUser.orgID.equals(GWID)
-						|| healthPortUser.orgID.equalsIgnoreCase(HVID)) {
-					patient.setId(healthPortUser.orgID + "."
-							+ healthPortUser.userId);
-					patient.getIdentifier()
-							.get(0)
-							.setValue(
-									healthPortUser.orgID + "."
-											+ healthPortUser.userId);
-				} else {
-					patient.setId(healthPortUser.orgID + "."
-							+ healthPortUser.personId);
-					patient.getIdentifier()
-							.get(0)
-							.setValue(
-									healthPortUser.orgID + "."
-											+ healthPortUser.personId);
-				}
-				String fullName = null;
-				if (userName.length == 2) {
-					patient.addName().addFamily(userName[1]);
-					patient.getName().get(0).addGiven(userName[0]);
-					fullName = userName[0] + " " + userName[1];
-				} else {
-					patient.addName().addFamily(userName[2]);
-					patient.getName().get(0)
-							.addGiven(userName[0] + " " + userName[1]);
-					fullName = userName[0] + " " + userName[1] + " "
-							+ userName[2];
-				}
-
-				// Gender
-				if (null == healthPortUser.gender) {
-					// Null check: Unknown gender
-					patient.setGender(AdministrativeGenderCodesEnum.UN);
-				} else if (healthPortUser.gender.equalsIgnoreCase("female")) {
-					patient.setGender(AdministrativeGenderCodesEnum.F);
-				} else if (healthPortUser.gender.equalsIgnoreCase("male")) {
-					patient.setGender(AdministrativeGenderCodesEnum.M);
-				} else {
-					// Unknown gender for all other values
-					patient.setGender(AdministrativeGenderCodesEnum.UN);
-				}
-
-				// ctx.setNarrativeGenerator(new
-				// DefaultThymeleafNarrativeGenerator());
-				// Encode the output, including the narrative
-				// String output =
-				// ctx.newXmlParser().setPrettyPrint(true).encodeResourceToString(patient);
-				patient.getText().setStatus(NarrativeStatusEnum.GENERATED);
-				String textBody = "<table><tr><td>Name</td><td>" + fullName
-						+ "</td></tr></table>";
-				patient.getText().setDiv(textBody);
+				// Process Java object into FHIR Patient Resource object
+				Patient patient = buildPatient(healthPortUser);
+				// Prepare to return Patient
 				retVal.add(patient);
 			}
 			connection.close();
@@ -184,4 +104,154 @@ public class PatientResourceProvider implements IResourceProvider {
 
 	}
 
+	/**
+	 * Transform a HealthPortInfo object into a Patient object.
+	 * 
+	 * @author Chris Harmoney
+	 * @since 2015-04-13
+	 * @param healthPortUser
+	 *            patient record to build
+	 * @return Patient representing the argument HealthPortInfo
+	 */
+	private Patient buildPatient(HealthPortInfo healthPortUser) {
+		Patient patient = new Patient();
+		String[] userName = healthPortUser.name.split(" ");
+
+		// Patient ID
+		patient.addIdentifier();
+		patient.getIdentifier().get(0)
+				.setSystem(new UriDt("urn:healthport:mrns"));
+		if (healthPortUser.orgID.equals(GWID)
+				|| healthPortUser.orgID.equalsIgnoreCase(HVID)) {
+			patient.setId(healthPortUser.orgID + "." + healthPortUser.userId);
+			patient.getIdentifier()
+					.get(0)
+					.setValue(
+							healthPortUser.orgID + "." + healthPortUser.userId);
+		} else {
+			patient.setId(healthPortUser.orgID + "." + healthPortUser.personId);
+			patient.getIdentifier()
+					.get(0)
+					.setValue(
+							healthPortUser.orgID + "."
+									+ healthPortUser.personId);
+		}
+
+		// Name
+		String fullName = null;
+		if (userName.length == 2) {
+			patient.addName().addFamily(userName[1]);
+			patient.getName().get(0).addGiven(userName[0]);
+			fullName = userName[0] + " " + userName[1];
+		} else {
+			patient.addName().addFamily(userName[2]);
+			patient.getName().get(0).addGiven(userName[0] + " " + userName[1]);
+			fullName = userName[0] + " " + userName[1] + " " + userName[2];
+		}
+
+		// Gender
+		if (null == healthPortUser.gender) {
+			// Null check: Unknown gender
+			patient.setGender(AdministrativeGenderCodesEnum.UN);
+		} else if (healthPortUser.gender.equalsIgnoreCase("female")) {
+			patient.setGender(AdministrativeGenderCodesEnum.F);
+		} else if (healthPortUser.gender.equalsIgnoreCase("male")) {
+			patient.setGender(AdministrativeGenderCodesEnum.M);
+		} else {
+			// Unknown gender for all other values
+			patient.setGender(AdministrativeGenderCodesEnum.UN);
+		}
+
+		// Date of Birth
+		if (null != healthPortUser.dob) {
+			// Sample data only includes DAY precision, not times
+			patient.setBirthDate(healthPortUser.dob, TemporalPrecisionEnum.DAY);
+		}
+
+		// Marital Status
+		// http://javadox.com/ca.uhn.hapi.fhir/hapi-fhir-base/0.4/ca/uhn/fhir/model/dstu/valueset/MaritalStatusCodesEnum.html
+		// http://hl7.org/fhir/vs/marital-status
+		// Code Display Definition
+		// A Annulled Marriage contract has been declared null and to not have
+		// existed
+		// D Divorced Marriage contract has been declared dissolved and inactive
+		// I Interlocutory Subject to an Interlocutory Decree.
+		// L Legally Separated
+		// M Married A current marriage contract is active
+		// P Polygamous More than 1 current spouse
+		// S Never Married No marriage contract has ever been entered
+		// T Domestic partner Person declares that a domestic partner
+		// relationship exists.
+		// W Widowed The spouse has died
+		if (null == healthPortUser.maritalStatus) {
+			// Null check: Unknown marital status
+			patient.setMaritalStatus(MaritalStatusCodesEnum.UNK);
+		} else if (healthPortUser.maritalStatus.equalsIgnoreCase("Annulled")) {
+			// Value not present in sample data, exact String is a guess
+			patient.setMaritalStatus(MaritalStatusCodesEnum.A);
+		} else if (healthPortUser.maritalStatus.equalsIgnoreCase("Divorced")) {
+			patient.setMaritalStatus(MaritalStatusCodesEnum.D);
+		} else if (healthPortUser.maritalStatus
+				.equalsIgnoreCase("Interlocutory")) {
+			// Value not present in sample data, exact String is a guess
+			patient.setMaritalStatus(MaritalStatusCodesEnum.I);
+		} else if (healthPortUser.maritalStatus
+				.equalsIgnoreCase("Legally Separated")) {
+			patient.setMaritalStatus(MaritalStatusCodesEnum.L);
+		} else if (healthPortUser.maritalStatus.equalsIgnoreCase("Married")) {
+			patient.setMaritalStatus(MaritalStatusCodesEnum.M);
+		} else if (healthPortUser.maritalStatus.equalsIgnoreCase("Polygamous")) {
+			// Value not present in sample data, exact String is a guess
+			patient.setMaritalStatus(MaritalStatusCodesEnum.P);
+		} else if (healthPortUser.maritalStatus.equalsIgnoreCase("Single")) {
+			patient.setMaritalStatus(MaritalStatusCodesEnum.S);
+		} else if (healthPortUser.maritalStatus
+				.equalsIgnoreCase("Domestic partner")) {
+			// Value not present in sample data, exact String is a guess
+			patient.setMaritalStatus(MaritalStatusCodesEnum.T);
+		} else if (healthPortUser.maritalStatus.equalsIgnoreCase("Widowed")) {
+			patient.setMaritalStatus(MaritalStatusCodesEnum.W);
+		} else {
+			// Unknown otherwise
+			patient.setMaritalStatus(MaritalStatusCodesEnum.UNK);
+		}
+
+		// Ethnicity not supported by
+		// ca.uhn.fhir.model.dstu.resource.Patient
+		// if (null != healthPortUser.ethnicity) {}
+
+		// Blood Type not supported by
+		// ca.uhn.fhir.model.dstu.resource.Patient
+		// if (null != healthPortUser.bloodType) {}
+
+		// Job not supported by
+		// ca.uhn.fhir.model.dstu.resource.Patient
+		// if (null != healthPortUser.job) {}
+
+		// Advance Directive not supported by
+		// ca.uhn.fhir.model.dstu.resource.Patient
+		// if (null != healthPortUser.advanceDirective) {}
+
+		// Organ Donor not supported by
+		// ca.uhn.fhir.model.dstu.resource.Patient
+		// if (null != healthPortUser.organDonor) {}
+
+		// HTML Representation
+		patient.getText().setStatus(NarrativeStatusEnum.GENERATED);
+		StringBuilder sb = new StringBuilder(
+				"<table><tr><th>Name</th><th>DOB</th><th>Gender</th><th>Marital Status</th></tr><tr><td>");
+		sb.append(fullName);
+		sb.append("</td><td>");
+		if (null != patient.getBirthDate()) {
+			sb.append(patient.getBirthDate().getValueAsString());
+		}
+		sb.append("</td><td>");
+		sb.append(Objects.toString(healthPortUser.gender, ""));
+		sb.append("</td><td>");
+		sb.append(Objects.toString(healthPortUser.maritalStatus, ""));
+		sb.append("</td></tr></table>");
+		patient.getText().setDiv(sb.toString());
+
+		return patient;
+	}
 }

--- a/src/edu/gatech/i3l/HealthPort/providers/PatientResourceProvider.java
+++ b/src/edu/gatech/i3l/HealthPort/providers/PatientResourceProvider.java
@@ -150,6 +150,19 @@ public class PatientResourceProvider implements IResourceProvider {
 							+ userName[2];
 				}
 
+				// Gender
+				if (null == healthPortUser.gender) {
+					// Null check: Unknown gender
+					patient.setGender(AdministrativeGenderCodesEnum.UN);
+				} else if (healthPortUser.gender.equalsIgnoreCase("female")) {
+					patient.setGender(AdministrativeGenderCodesEnum.F);
+				} else if (healthPortUser.gender.equalsIgnoreCase("male")) {
+					patient.setGender(AdministrativeGenderCodesEnum.M);
+				} else {
+					// Unknown gender for all other values
+					patient.setGender(AdministrativeGenderCodesEnum.UN);
+				}
+
 				// ctx.setNarrativeGenerator(new
 				// DefaultThymeleafNarrativeGenerator());
 				// Encode the output, including the narrative

--- a/src/edu/gatech/i3l/HealthPort/providers/PatientResourceProvider.java
+++ b/src/edu/gatech/i3l/HealthPort/providers/PatientResourceProvider.java
@@ -6,21 +6,16 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.naming.Context;
-import javax.sql.DataSource;
-
-import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.model.dstu.resource.Patient;
+import ca.uhn.fhir.model.dstu.valueset.AdministrativeGenderCodesEnum;
 import ca.uhn.fhir.model.dstu.valueset.NarrativeStatusEnum;
 import ca.uhn.fhir.model.primitive.IdDt;
 import ca.uhn.fhir.model.primitive.UriDt;
-import ca.uhn.fhir.narrative.DefaultThymeleafNarrativeGenerator;
 import ca.uhn.fhir.rest.annotation.IdParam;
 import ca.uhn.fhir.rest.annotation.Read;
 import ca.uhn.fhir.rest.annotation.Search;
 import ca.uhn.fhir.rest.server.IResourceProvider;
 import edu.gatech.i3l.HealthPort.HealthPortInfo;
-import edu.gatech.i3l.HealthPort.ports.ExactDataPort;
 import edu.gatech.i3l.HealthPort.ports.GreenwayPort;
 import edu.gatech.i3l.HealthPort.ports.HealthVaultPort;
 
@@ -161,8 +156,8 @@ public class PatientResourceProvider implements IResourceProvider {
 				// String output =
 				// ctx.newXmlParser().setPrettyPrint(true).encodeResourceToString(patient);
 				patient.getText().setStatus(NarrativeStatusEnum.GENERATED);
-				String textBody = "<table>" + "<tr><td>Name</td><td>"
-						+ fullName + "</td></tr></table>";
+				String textBody = "<table><tr><td>Name</td><td>" + fullName
+						+ "</td></tr></table>";
 				patient.getText().setDiv(textBody);
 				retVal.add(patient);
 			}

--- a/src/edu/gatech/i3l/HealthPort/providers/PatientResourceProvider.java
+++ b/src/edu/gatech/i3l/HealthPort/providers/PatientResourceProvider.java
@@ -29,140 +29,151 @@ import edu.gatech.i3l.HealthPort.ports.HealthVaultPort;
  */
 public class PatientResourceProvider implements IResourceProvider {
 	public static final String SQL_STATEMENT = "SELECT U1.ID, U1.ORGANIZATIONID, U1.NAME, ORG.TAG, U1.RECORDID, U1.PERSONID, U1.GENDER, U1.CONTACT, U1.ADDRESS FROM USER AS U1 LEFT JOIN ORGANIZATION AS ORG ON (ORG.ID=U1.ORGANIZATIONID)";
- 
+
 	private HealthPortInfo healthPortUser;
 	private String GWID;
 	private String HVID;
-	
-	public PatientResourceProvider () {
-		healthPortUser = new HealthPortInfo ("jdbc/HealthPort");
+
+	public PatientResourceProvider() {
+		healthPortUser = new HealthPortInfo("jdbc/HealthPort");
 		GWID = healthPortUser.getOrgID(GreenwayPort.GREENWAY);
 		HVID = healthPortUser.getOrgID(HealthVaultPort.HEALTHVAULT);
 	}
-	
-    /**
-     * The getResourceType method comes from IResourceProvider, and must
-     * be overridden to indicate what type of resource this provider
-     * supplies.
-     */
-    @Override
-    public Class<Patient> getResourceType() {
-        return Patient.class;
-    }
-    
-    @Read()
-    public Patient getResourceById(@IdParam IdDt theId){
-    	Patient patient = new Patient();
-//    	FhirContext ctx = new FhirContext();
-//    	int id = Integer.parseInt(theId.getIdPart());
-//    	HealthPortUserInfo HealthPortUser = new HealthPortUserInfo(id);
-    	
-    	String Ids[] = theId.getIdPart().split("\\.", 2);
-    	String patientID;
-    	
-    	if (Ids.length != 2) {
-    		return patient;
-    	}
-    	if (Ids[0].equals(GWID) ||
-    			Ids[0].equals(HVID)) {
-    		healthPortUser.setInformation(Ids[1]);
-    		patientID = healthPortUser.orgID+"."+healthPortUser.userId;
-    	} else {
-    		healthPortUser.setInformationPersonID(Ids[1], Ids[0]);
-    		patientID = healthPortUser.orgID+"."+healthPortUser.personId;
-    	}
-    	
-    	if (healthPortUser.orgID == null) return null;
+
+	/**
+	 * The getResourceType method comes from IResourceProvider, and must be
+	 * overridden to indicate what type of resource this provider supplies.
+	 */
+	@Override
+	public Class<Patient> getResourceType() {
+		return Patient.class;
+	}
+
+	@Read()
+	public Patient getResourceById(@IdParam IdDt theId) {
+		Patient patient = new Patient();
+		// FhirContext ctx = new FhirContext();
+		// int id = Integer.parseInt(theId.getIdPart());
+		// HealthPortUserInfo HealthPortUser = new HealthPortUserInfo(id);
+
+		String Ids[] = theId.getIdPart().split("\\.", 2);
+		String patientID;
+
+		if (Ids.length != 2) {
+			return patient;
+		}
+		if (Ids[0].equals(GWID) || Ids[0].equals(HVID)) {
+			healthPortUser.setInformation(Ids[1]);
+			patientID = healthPortUser.orgID + "." + healthPortUser.userId;
+		} else {
+			healthPortUser.setInformationPersonID(Ids[1], Ids[0]);
+			patientID = healthPortUser.orgID + "." + healthPortUser.personId;
+		}
+
+		if (healthPortUser.orgID == null)
+			return null;
 
 		patient.addIdentifier();
-		patient.getIdentifier().get(0).setSystem(new UriDt("urn:healthport:mrns"));
+		patient.getIdentifier().get(0)
+				.setSystem(new UriDt("urn:healthport:mrns"));
 		patient.setId(patientID);
 		patient.getIdentifier().get(0).setValue(patientID);
 
 		String fullName = null;
 
-		String[] userName  = healthPortUser.name.split(" ");
-        if (userName.length == 2){
-            patient.addName().addFamily(userName[1]);
-            patient.getName().get(0).addGiven(userName[0]);
-            fullName = userName[0] + " "+userName[1];
-        }
-        else{
-            patient.addName().addFamily(userName[2]);
-            patient.getName().get(0).addGiven(userName[0]+ " "+ userName[1]);
-            fullName = userName[0] + " "+userName[1]+ " "+userName[2];
-        }
-//		ctx.setNarrativeGenerator(new DefaultThymeleafNarrativeGenerator());
-//		// Encode the output, including the narrative
-//		String output = ctx.newXmlParser().setPrettyPrint(true).encodeResourceToString(patient);
-//		//patient.getText().setDiv(output);
-    	
+		String[] userName = healthPortUser.name.split(" ");
+		if (userName.length == 2) {
+			patient.addName().addFamily(userName[1]);
+			patient.getName().get(0).addGiven(userName[0]);
+			fullName = userName[0] + " " + userName[1];
+		} else {
+			patient.addName().addFamily(userName[2]);
+			patient.getName().get(0).addGiven(userName[0] + " " + userName[1]);
+			fullName = userName[0] + " " + userName[1] + " " + userName[2];
+		}
+		// ctx.setNarrativeGenerator(new DefaultThymeleafNarrativeGenerator());
+		// // Encode the output, including the narrative
+		// String output =
+		// ctx.newXmlParser().setPrettyPrint(true).encodeResourceToString(patient);
+		// //patient.getText().setDiv(output);
+
 		patient.getText().setStatus(NarrativeStatusEnum.GENERATED);
-		String textBody = "<table>"
-				+ "<tr><td>Name</td><td>"+ fullName
+		String textBody = "<table>" + "<tr><td>Name</td><td>" + fullName
 				+ "</td></tr></table>";
-	    patient.getText().setDiv(textBody);
-		
-    	return patient;
-    }
-     
-    
-    @Search
-    public List<Patient> getAllPatients() {
-    	//System.out.println("HERE");
-    	Connection connection = null;
+		patient.getText().setDiv(textBody);
+
+		return patient;
+	}
+
+	@Search
+	public List<Patient> getAllPatients() {
+		// System.out.println("HERE");
+		Connection connection = null;
 		Statement statement = null;
-				
+
 		ArrayList<Patient> retVal = new ArrayList<Patient>();
-    	try{
-    		connection = healthPortUser.getConnection();
+		try {
+			connection = healthPortUser.getConnection();
 			statement = connection.createStatement();
 			ResultSet resultSet = statement.executeQuery(SQL_STATEMENT);
 			while (resultSet.next()) {
 				healthPortUser.setRSInformation(resultSet);
-				String[] userName  = healthPortUser.name.split(" ");
-				
+				String[] userName = healthPortUser.name.split(" ");
+
 				Patient patient = new Patient();
 				patient.addIdentifier();
-				patient.getIdentifier().get(0).setSystem(new UriDt("urn:healthport:mrns"));
-				if (healthPortUser.orgID.equals(GWID) ||
-						healthPortUser.orgID.equalsIgnoreCase(HVID)) {
-					patient.setId(healthPortUser.orgID+"."+healthPortUser.userId);
-					patient.getIdentifier().get(0).setValue(healthPortUser.orgID+"."+healthPortUser.userId);
+				patient.getIdentifier().get(0)
+						.setSystem(new UriDt("urn:healthport:mrns"));
+				if (healthPortUser.orgID.equals(GWID)
+						|| healthPortUser.orgID.equalsIgnoreCase(HVID)) {
+					patient.setId(healthPortUser.orgID + "."
+							+ healthPortUser.userId);
+					patient.getIdentifier()
+							.get(0)
+							.setValue(
+									healthPortUser.orgID + "."
+											+ healthPortUser.userId);
 				} else {
-					patient.setId(healthPortUser.orgID+"."+healthPortUser.personId);
-					patient.getIdentifier().get(0).setValue(healthPortUser.orgID+"."+healthPortUser.personId);
+					patient.setId(healthPortUser.orgID + "."
+							+ healthPortUser.personId);
+					patient.getIdentifier()
+							.get(0)
+							.setValue(
+									healthPortUser.orgID + "."
+											+ healthPortUser.personId);
 				}
 				String fullName = null;
-		        if (userName.length == 2){
-                    patient.addName().addFamily(userName[1]);
-                    patient.getName().get(0).addGiven(userName[0]);
-                    fullName = userName[0] + " "+userName[1];
-		        }
-		        else{
-                    patient.addName().addFamily(userName[2]);
-                    patient.getName().get(0).addGiven(userName[0]+ " "+ userName[1]);
-                    fullName = userName[0] + " "+userName[1]+ " "+userName[2];
-		        }
-		        
-				//ctx.setNarrativeGenerator(new DefaultThymeleafNarrativeGenerator());
+				if (userName.length == 2) {
+					patient.addName().addFamily(userName[1]);
+					patient.getName().get(0).addGiven(userName[0]);
+					fullName = userName[0] + " " + userName[1];
+				} else {
+					patient.addName().addFamily(userName[2]);
+					patient.getName().get(0)
+							.addGiven(userName[0] + " " + userName[1]);
+					fullName = userName[0] + " " + userName[1] + " "
+							+ userName[2];
+				}
+
+				// ctx.setNarrativeGenerator(new
+				// DefaultThymeleafNarrativeGenerator());
 				// Encode the output, including the narrative
-				//String output = ctx.newXmlParser().setPrettyPrint(true).encodeResourceToString(patient);
+				// String output =
+				// ctx.newXmlParser().setPrettyPrint(true).encodeResourceToString(patient);
 				patient.getText().setStatus(NarrativeStatusEnum.GENERATED);
-				String textBody = "<table>"
-						+ "<tr><td>Name</td><td>"+ fullName
-						+ "</td></tr></table>";
-			    patient.getText().setDiv(textBody);
-		        retVal.add(patient);
+				String textBody = "<table>" + "<tr><td>Name</td><td>"
+						+ fullName + "</td></tr></table>";
+				patient.getText().setDiv(textBody);
+				retVal.add(patient);
 			}
 			connection.close();
-			
-		} catch (Exception e){
+
+		} catch (Exception e) {
 			e.printStackTrace();
 		}
-    
-       return retVal;
 
-    }
- 
+		return retVal;
+
+	}
+
 }


### PR DESCRIPTION
Extended Patient Resource to support additional fields provided in the sample dataset.  Also includes code clean up, formatting, and some security refactoring.

The SQL script `fhir_patient_alter_update.sql` must be executed before these changes are deployed.  The SQL file creates new database fields expected by the Java changes.  The script was emailed to Amelia and Apoorva on 4/12/2015 (4/13/2015 Eastern Time).

Test cases, to be run from a command line console with curl and python (> 2.5) available.

``` bash
#
# HealthVault record
#
# Valid, should return record
curl --verbose 'http://localhost:8080/HealthPort/fhir/Patient/1.1?_format=json' | python -mjson.tool
# Invalid, should 404
curl --verbose 'http://localhost:8080/HealthPort/fhir/Patient/1.0?_format=json' | python -mjson.tool

#
# SyntheticEHR record
#
# Valid, should return record
curl --verbose 'http://localhost:8080/HealthPort/fhir/Patient/3.937650000-01?_format=json' | python -mjson.tool
# Invalid, should 404
curl --verbose 'http://localhost:8080/HealthPort/fhir/Patient/3.937650000-00?_format=json' | python -mjson.tool

#
# SyntheticCancer 
#
# Valid, should return record
curl --verbose 'http://localhost:8080/HealthPort/fhir/Patient/4.666281525-01?_format=json' | python -mjson.tool
# Invalid, should 404
curl --verbose 'http://localhost:8080/HealthPort/fhir/Patient/4.666281525-00?_format=json' | python -mjson.tool

#
# Patient searches
#
PT_URL="http://localhost:8080/HealthPort/fhir/Patient?_count=2&_format=json"
# Re-run this line repeatedly to advance to future pages. Each execution gets the next "next" page
PT_URL=$(curl "$PT_URL" 2>/dev/null | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["link"][1]["href"] if "next" == obj["link"][1]["rel"] else obj["link"][2]["href"];'); echo $PT_URL | cut -d'&' -f2
# Run this to see the selected future page
curl --verbose "$PT_URL" | python -mjson.tool
```
