### PR TITLE
Minor fix for MedicationPrescription search by patient

### DIFF
--- a/src/edu/gatech/i3l/HealthPort/providers/MedicationPrescrResource.java
+++ b/src/edu/gatech/i3l/HealthPort/providers/MedicationPrescrResource.java
@@ -179,7 +179,7 @@ public class MedicationPrescrResource implements IResourceProvider {
 
 	@Search()
 	public IBundleProvider getMedicationPrescriptionsByPatient(
-			@RequiredParam(name = Condition.SP_SUBJECT) ReferenceParam theSubject) {
+			@RequiredParam(name = MedicationPrescription.SP_PATIENT) ReferenceParam theSubject) {
 		final InstantDt searchTime = InstantDt.withCurrentTime();
 		String patientID = theSubject.getIdPart();
 


### PR DESCRIPTION
This is a really minor fix for an annoying bug in the HealthPort server as its currently deployed. (No need for extra credit, just wanting to make the code better for the next class!)

The FHIR DSTU spec says that you should be able to search MedicationPrescription resources with the keyword "patient", but the current HealthPort code uses the "subject" paramter for this instead.

"Incorrect" URL that works on the current version:
[http://localhost:8080/HealthPort/fhir/MedicationPrescription?patient:Patient=Patient/3.568001602-01]()

Corrected URL that works after this update:
[http://localhost:8080/HealthPort/fhir/MedicationPrescription?patient:Patient=Patient/3.568001602-01]()

An alternate solution would be to duplicate the `getMedicationPrescriptionsByPatient()` method so one accepts 'subject' and the other accepts 'patient' (for backwards compatibility), but for future use I believe it's better to follow the spec to avoid confusion.
